### PR TITLE
chore: add devcontainer, tweak docs/settings

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,44 @@
+// See https://containers.dev/implementors/json_reference/ for configuration reference
+{
+  "name": "nginx-directive-reference",
+  "build": {
+    "dockerfile": "../tools/devtools/Dockerfile",
+    "args": {
+      "BASE_IMG": "mcr.microsoft.com/devcontainers/typescript-node:0-18-bullseye"
+    }
+  },
+  "postCreateCommand": "sudo chown node:node reference-lib/node_modules",
+  "remoteUser": "node",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "golang.go",
+        "ms-vsliveshare.vsliveshare",
+        "ms-azuretools.vscode-docker",
+        "esbenp.prettier-vscode",
+        "eamodio.gitlens",
+        "orta.vscode-jest"
+      ],
+      "settings": {
+        "files.trimTrailingWhitespace": true,
+        "files.insertFinalNewline": true,
+        "editor.formatOnSave": true,
+        "[typescript][json][jsonc][yaml][markdown][javascript]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode",
+          "editor.codeActionsOnSave": {
+            "source.fixAll": true
+          }
+        },
+        "eslint.workingDirectories": ["./reference-lib"],
+        "go.testFlags": ["-v", "-count=1"],
+        "go.lintTool": "golangci-lint",
+        "go.lintFlags": ["--fast"]
+      }
+    }
+  },
+  "mounts": [
+    // keep node_modules in the container for speed on macos/windows
+    "source=${localWorkspaceFolderBasename}-reference-lib-node_modules,target=${containerWorkspaceFolder}/reference-lib/node_modules,type=volume"
+  ]
+}

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,4 @@
+# style settings, see https://prettier.io/docs/en/options.html
+semi: false
+singleQuote: true
+trailingComma: es5

--- a/README.md
+++ b/README.md
@@ -1,35 +1,33 @@
-[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
+[![Project Status: WIP – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 [![License](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Community Support](https://badgen.net/badge/support/community/cyan?icon=awesome)](https://github.com/nginxinc/nginx-directive-reference/blob/main/SUPPORT.md)
-
+[![Community Support](https://badgen.net/badge/support/community/cyan?icon=awesome)](SUPPORT.md)
 
 # NGINX Directive Reference
-This repo contains the reference-lib npm package that can be used to fetch NGINX directive reference in Markdown and HTML format. It also has the converter code that is used to generate the directive reference json.
 
+This repo contains the reference-lib npm package that can be used to fetch NGINX directive reference in Markdown and HTML format. It also has the converter code that is used to generate the directive reference json.
 
 ## Getting Started
 
-Refer to the [README file](https://github.com/nginxinc/nginx-directive-reference/blob/main/reference-lib/README.md) for how to install the reference-lib package.
+Refer to the [README file](reference-lib/README.md) for how to install the reference-lib package.
 
-Refer to the [README file](https://github.com/nginxinc/nginx-directive-reference/blob/main/reference-converter/README.md) for how to build and run the reference converter.
+Refer to the [README file](reference-converter/README.md) for how to build and run the reference converter.
 
+This project includes a [devcontainer](https://containers.dev/overview) with all dependencies pre-installed and configured.
 
 ## Directory Structure
+
 The repository is organized as follows:
 
-reference-lib/: This directory contains an npm package that allows for easy lookup of nginx directives
-
-reference-converter/: This directory contains a program that converts the official NGINX reference documentation in XML format to JSON.
-
-tools/: This directory contains development tools
-
+- `reference-lib/`: This directory contains an npm package that allows for easy lookup of nginx directives
+- `reference-converter/`: This directory contains a program that converts the official NGINX reference documentation from XML format to JSON.
+- `tools/`: This directory contains development tools
 
 ## Contributing
 
-Please see the [contributing guide](https://github.com/nginxinc/nginx-directive-reference/blob/main/CONTRIBUTING.md) for guidelines on how to best contribute to this project.
+Please see the [contributing guide](CONTRIBUTING.md) for guidelines on how to best contribute to this project.
 
 ## License
 
-[Apache License, Version 2.0](https://github.com/nginxinc/nginx-directive-reference/blob/main/LICENSE)
+[Apache License, Version 2.0](LICENSE)
 
 &copy; [F5, Inc.](https://www.f5.com/) 2023

--- a/tools/devtools/Dockerfile
+++ b/tools/devtools/Dockerfile
@@ -14,7 +14,6 @@ RUN go install github.com/jstemmer/go-junit-report/v2@${GO_JUNIT_REPORT_VERSION}
     && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v${GOLANGCI_LINT_VERSION}
 
 FROM $BASE_IMG
-ARG DOCKER_VERSION=23.0.6
 
 # copy golang tools in
 COPY --from=golang /go/bin/* /go/bin/
@@ -24,12 +23,6 @@ ENV PATH=/go/bin:/usr/local/go/bin:${PATH} \
 
 RUN apt-get update -y \
     && apt-get install -y xz-utils curl \
-    # install docker
-    && export ARCH=$(dpkg --print-architecture) \
-    && export DOCKER_ARCH=$(case $ARCH in "arm64") echo "aarch64" ;; "amd64") echo "x86_64" ;; esac;) \
-    && export DOCKER_URL=https://download.docker.com/linux/static/stable/${DOCKER_ARCH}/docker-${DOCKER_VERSION}.tgz \
-    && curl -sSfL "$DOCKER_URL" -o /tmp/docker.tgz \
-    && tar xzvf /tmp/docker.tgz --strip 1 -C /usr/local/bin docker/docker \
     # create default location for devtools scripts
     && mkdir /opt/devtools && chmod -R 777 /opt/devtools \
     # tell git it's ok if the permissions are screwy


### PR DESCRIPTION


### Proposed changes

Adds a devcontainer to wrap up all the dependencies and config. The NGINX template wants to ignore the `.vscode` folder, so embedded all the vscode settings into the devcontainer config itself.

Along the way did a few docs and settings tweaks to drop features carried over from the previous repo that aren't needed here.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-directive-reference/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-directive-reference/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-directive-reference/blob/main/CHANGELOG.md))
