### PR TITLE
Add color theme for nginx editor

### DIFF
--- a/examples/theme.ts
+++ b/examples/theme.ts
@@ -1,0 +1,61 @@
+import type { editor } from "monaco-editor/esm/vs/editor/editor.api";
+
+export const themeConfig: editor.IStandaloneThemeData = {
+    colors: {
+        // 'attribute.value.unit': '#68217a'
+    },
+    base: "vs",
+    inherit: true,
+    rules: [
+        {
+            token: "nginx.toplevel",
+            foreground: "#B58440",
+            fontStyle: "bold",
+        },
+        {
+            token: "nginx.top.block",
+            foreground: "#4071B5",
+            fontStyle: "bold",
+        },
+        {
+            token: "nginx.block",
+            foreground: "#B540AB",
+            fontStyle: "bold",
+        },
+        {
+            token: "nginx.directives",
+            foreground: "#40b54a", 
+            fontStyle: "bold",
+        },
+    ],
+};
+
+export const themeDarkConfig: editor.IStandaloneThemeData = {
+    colors: {
+        // 'attribute.value.unit': '#68217a'
+    },
+    base: "vs-dark",
+    inherit: true,
+    rules: [
+        {
+            token: "nginx.toplevel",
+            foreground: "#B58440",
+            fontStyle: "bold",
+        },
+        {
+            token: "nginx.top.block",
+            foreground: "#4071B5",
+            fontStyle: "bold",
+        },
+        {
+            token: "nginx.block",
+            foreground: "#B540AB",
+            fontStyle: "bold",
+        },
+        {
+            token: "nginx.directives",
+            foreground: "#40b54a", 
+            fontStyle: "bold",
+        },
+    ],
+};


### PR DESCRIPTION
### Proposed changes

Add color theme for nginx editor  with light and dark version

<img width="640" alt="image" src="https://github.com/nginxinc/nginx-directive-reference/assets/42621884/8fdf3c31-5ce7-406c-99fc-7f4b3c9c9261">


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-directive-reference/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-directive-reference/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-directive-reference/blob/main/CHANGELOG.md))
