### PR TITLE
ci: deploy to npm instead of github packages

### DIFF
--- a/.github/workflows/reference-lib.publish.yml
+++ b/.github/workflows/reference-lib.publish.yml
@@ -1,4 +1,4 @@
-name: Publish reference lib package to GitHub Packages
+name: Publish reference lib package to NPM
 on:
   push:
     branches: ['main']
@@ -12,36 +12,31 @@ defaults:
     working-directory: ./reference-lib
     shell: bash
 
-
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: '16.x'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@nginxinc'
+          registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         run: npm ci
       - name: Test it out
         run: npm run test
       - name: Bundle using rollup
         run: npm run build
-      - name: get package-version
-        run: node -p -e '`PACKAGE_VERSION=${require("./package.json").version}`' >> $GITHUB_ENV
       - name: publish package
         if: github.event_name == 'push'
         run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create and push tag
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Create and push tag matching the npm package
         if: github.event_name == 'push'
-        uses: mathieudutour/github-tag-action@v6.2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          custom_tag: ${{ env.PACKAGE_VERSION }}
+        run: |
+          export PACKAGE_VERSION=v$(node -p -e 'require("./package.json").version')
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git tag -a "$PACKAGE_VERSION" -m "Release $PACKAGE_VERSION"
+          git push origin "$PACKAGE_VERSION"

--- a/reference-lib/package.json
+++ b/reference-lib/package.json
@@ -5,12 +5,12 @@
   "main": "dist/index.js",
   "type": "module",
   "scripts": {
-    "build": "./node_modules/.bin/rollup -c",
+    "build": "rollup -c",
     "test": "jest --coverage"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/nginxinc/nginx-directive-reference.git"
+    "url": "git+https://github.com/nginx/nginx-directive-reference.git"
   },
   "devDependencies": {
     "@rollup/plugin-json": "^6.1.0",
@@ -22,5 +22,8 @@
   },
   "files": [
     "dist/**/*"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
 }


### PR DESCRIPTION
### Proposed changes

Targets the public npm registry instead of the private github packages to make this as easy to consume as possible.

Drop the dependency on a third party action for tagging, it's only a few lines to add a tag, and the action was broken. Going with one less dependency to keep up with.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-directive-reference/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-directive-reference/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-directive-reference/blob/main/CHANGELOG.md))
