### PR TITLE
chore: update golang versions

### DIFF
--- a/reference-converter/go.mod
+++ b/reference-converter/go.mod
@@ -1,9 +1,9 @@
 module github.com/nginxinc/nginx-directive-reference/reference-converter
 
-go 1.21
+go 1.23
 
 require (
-	github.com/gomarkdown/markdown v0.0.0-20230716120725-531d2d74bc12
+	github.com/gomarkdown/markdown v0.0.0-20241205020045-f7e15b2f3e62
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/reference-converter/go.sum
+++ b/reference-converter/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/gomarkdown/markdown v0.0.0-20230716120725-531d2d74bc12 h1:uK3X/2mt4tbSGoHvbLBHUny7CKiuwUip3MArtukol4E=
-github.com/gomarkdown/markdown v0.0.0-20230716120725-531d2d74bc12/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
+github.com/gomarkdown/markdown v0.0.0-20241205020045-f7e15b2f3e62 h1:pbAFUZisjG4s6sxvRJvf2N7vhpCvx2Oxb3PmS6pDO1g=
+github.com/gomarkdown/markdown v0.0.0-20241205020045-f7e15b2f3e62/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=

--- a/tools/devtools/Dockerfile
+++ b/tools/devtools/Dockerfile
@@ -1,12 +1,12 @@
-ARG GO_VERSION=1.21
+ARG GO_VERSION=1.23
 ARG NODE_VERSION=18
 ARG BASE_IMG=docker.io/library/node:${NODE_VERSION}-bullseye
 
-FROM docker.io/library/golang:${GO_VERSION}-bullseye as golang
+FROM docker.io/library/golang:${GO_VERSION}-bullseye AS golang
 ARG GO_JUNIT_REPORT_VERSION=latest
 ARG GOPLS_VERSION=latest
 ARG DELVE_VERSION=latest
-ARG GOLANGCI_LINT_VERSION=1.54.1
+ARG GOLANGCI_LINT_VERSION=1.62.2
 
 RUN go install github.com/jstemmer/go-junit-report/v2@${GO_JUNIT_REPORT_VERSION} \
     && go install -v golang.org/x/tools/gopls@${GOPLS_VERSION} \


### PR DESCRIPTION
### Proposed changes

Fix a broken build by upgrading to the latest golang version.

Also updated `gomarkdown` to resolve some low-priority security notices and `golangci-lint` to keep up with the golang version.

The build broke because we're using "latest" versions of some dev libraries. I considered pinning those instead of upgrading golang, but "latest" fails infrequently, and we're already two minor versions behind on golang so needed to update anyway.

If we have a similar failure will switch to a `tools.go` approach and manage tool versions in go.mod with the rest of the dependencies.

fixes #307

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-directive-reference/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-directive-reference/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-directive-reference/blob/main/CHANGELOG.md))
