### PR TITLE
bump golang to 1.24

### DIFF
--- a/reference-converter/go.mod
+++ b/reference-converter/go.mod
@@ -1,6 +1,6 @@
 module github.com/nginxinc/nginx-directive-reference/reference-converter
 
-go 1.23
+go 1.24
 
 require (
 	github.com/gomarkdown/markdown v0.0.0-20241205020045-f7e15b2f3e62

--- a/tools/devtools/Dockerfile
+++ b/tools/devtools/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.23
+ARG GO_VERSION=1.24
 ARG NODE_VERSION=18
 ARG BASE_IMG=docker.io/library/node:${NODE_VERSION}-bullseye
 
@@ -6,7 +6,7 @@ FROM docker.io/library/golang:${GO_VERSION}-bullseye AS golang
 ARG GO_JUNIT_REPORT_VERSION=latest
 ARG GOPLS_VERSION=latest
 ARG DELVE_VERSION=latest
-ARG GOLANGCI_LINT_VERSION=1.62.2
+ARG GOLANGCI_LINT_VERSION=1.64.8
 
 RUN go install github.com/jstemmer/go-junit-report/v2@${GO_JUNIT_REPORT_VERSION} \
     && go install -v golang.org/x/tools/gopls@${GOPLS_VERSION} \


### PR DESCRIPTION
### Proposed changes

Upgrade to go1.24. 

The build is failing because the latest `gopls` requires 1.24 or above.

Considered pinning `gopls`, but figured we need to upgrade Go anyway.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-directive-reference/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-directive-reference/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-directive-reference/blob/main/CHANGELOG.md))
