### PR TITLE
bump golang to 1.26

### DIFF
--- a/reference-converter/go.mod
+++ b/reference-converter/go.mod
@@ -1,6 +1,6 @@
 module github.com/nginxinc/nginx-directive-reference/reference-converter
 
-go 1.25
+go 1.26
 
 require (
 	github.com/gomarkdown/markdown v0.0.0-20241205020045-f7e15b2f3e62

--- a/reference-converter/internal/parse/code_test.go
+++ b/reference-converter/internal/parse/code_test.go
@@ -23,7 +23,6 @@ func TestCodeBlocks(t *testing.T) {
 		"value":   {XML: `<value>val</value>`, want: "*`val`*"},
 	}
 	for name, tc := range testcases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -32,7 +31,7 @@ func TestCodeBlocks(t *testing.T) {
 			}
 
 			var d doc
-			err := xml.Unmarshal([]byte(fmt.Sprintf("<doc><para>%s</para></doc>", tc.XML)), &d)
+			err := xml.Unmarshal(fmt.Appendf(nil, "<doc><para>%s</para></doc>", tc.XML), &d)
 			require.NoError(t, err)
 
 			got := d.Got.ToMarkdown()

--- a/reference-converter/internal/parse/link_test.go
+++ b/reference-converter/internal/parse/link_test.go
@@ -57,7 +57,6 @@ func TestLink_ToMarkdown(t *testing.T) {
 		},
 	}
 	for name, tc := range testcases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			files := append(pages, testModuleFile(t, withContent(tc.XML)))

--- a/reference-converter/internal/parse/list.go
+++ b/reference-converter/internal/parse/list.go
@@ -14,7 +14,7 @@ type unorderedList struct {
 func (t *unorderedList) ToMarkdown() string {
 	var sb strings.Builder
 	for _, item := range t.Items {
-		sb.WriteString(fmt.Sprintf("-%s\n", item.ToIndentedMarkdown(false)))
+		fmt.Fprintf(&sb, "-%s\n", item.ToIndentedMarkdown(false))
 	}
 	return sb.String()
 }
@@ -27,7 +27,7 @@ type orderedList struct {
 func (t *orderedList) ToMarkdown() string {
 	var sb strings.Builder
 	for i, item := range t.Items {
-		sb.WriteString(fmt.Sprintf("%d.%s\n", i+1, item.ToIndentedMarkdown(false)))
+		fmt.Fprintf(&sb, "%d.%s\n", i+1, item.ToIndentedMarkdown(false))
 	}
 	return sb.String()
 }
@@ -49,8 +49,8 @@ func (t *taglist) ToMarkdown() string {
 	for i := range t.TagNames {
 		name := t.TagNames[i]
 		desc := t.TagDesc[i]
-		sb.WriteString(fmt.Sprintf(
-			"- %s\n\n%s\n", name.ToTrimmedMarkdown(), desc.ToIndentedMarkdown(true)))
+		fmt.Fprintf(&sb,
+			"- %s\n\n%s\n", name.ToTrimmedMarkdown(), desc.ToIndentedMarkdown(true))
 
 	}
 	return sb.String()

--- a/reference-converter/internal/parse/markdown.go
+++ b/reference-converter/internal/parse/markdown.go
@@ -188,7 +188,7 @@ func (n *note) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 		if len(line) == 0 {
 			continue
 		}
-		sb.WriteString(fmt.Sprintf("> %s\n", line))
+		fmt.Fprintf(&sb, "> %s\n", line)
 	}
 	*n = note{content: sb.String()}
 	return nil

--- a/reference-converter/internal/parse/markdown.go
+++ b/reference-converter/internal/parse/markdown.go
@@ -184,7 +184,7 @@ func (n *note) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	}
 	// add a '>' prefix to each line
 	var sb strings.Builder
-	for _, line := range strings.Split(content, "\n") {
+	for line := range strings.SplitSeq(content, "\n") {
 		if len(line) == 0 {
 			continue
 		}

--- a/reference-converter/internal/parse/markdown_test.go
+++ b/reference-converter/internal/parse/markdown_test.go
@@ -255,7 +255,6 @@ func TestMarkdown(t *testing.T) {
 		},
 	}
 	for name, tc := range testcases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/reference-converter/internal/parse/parse_test.go
+++ b/reference-converter/internal/parse/parse_test.go
@@ -83,7 +83,6 @@ func TestParse(t *testing.T) {
 		},
 	}
 	for name, tc := range testcases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			f := readTestFile(t, tc.filename)

--- a/reference-converter/internal/parse/utils_test.go
+++ b/reference-converter/internal/parse/utils_test.go
@@ -105,7 +105,7 @@ func testArticleFile(path, name string) tarball.File {
 
 	return tarball.File{
 		Name:     path,
-		Contents: []byte(fmt.Sprintf(tmpl, link, name)),
+		Contents: fmt.Appendf(nil, tmpl, link, name),
 	}
 }
 

--- a/tools/devtools/Dockerfile
+++ b/tools/devtools/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.26
 ARG NODE_VERSION=24
 ARG BASE_IMG=docker.io/library/node:${NODE_VERSION}-trixie
 
@@ -6,12 +6,12 @@ FROM docker.io/library/golang:${GO_VERSION}-trixie AS golang
 ARG GO_JUNIT_REPORT_VERSION=latest
 ARG GOPLS_VERSION=latest
 ARG DELVE_VERSION=latest
-ARG GOLANGCI_LINT_VERSION=2.7.2
+ARG GOLANGCI_LINT_VERSION=2.12.2
 
 RUN go install github.com/jstemmer/go-junit-report/v2@${GO_JUNIT_REPORT_VERSION} \
     && go install -v golang.org/x/tools/gopls@${GOPLS_VERSION} \
     && go install github.com/go-delve/delve/cmd/dlv@${DELVE_VERSION} \
-    && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v${GOLANGCI_LINT_VERSION}
+    && curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(go env GOPATH)/bin v${GOLANGCI_LINT_VERSION}
 
 FROM $BASE_IMG
 


### PR DESCRIPTION
### Proposed changes

The build is failing because the latest `gopls` requires 1.26 or above.

Considered pinning `gopls` again, but figured we need to upgrade Go anyway.

fixes #552

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-directive-reference/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-directive-reference/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-directive-reference/blob/main/CHANGELOG.md))
