### PR TITLE
ci: refactor workflows to support trusted publishing / OIDC

### DIFF
--- a/.github/workflows/reference-lib.tag.yml
+++ b/.github/workflows/reference-lib.tag.yml
@@ -1,0 +1,31 @@
+name: Tag when we merge a new reference-lib/package.json version
+
+on:
+  push:
+    branches: ['main']
+    paths: ['reference-lib/**']
+
+permissions:
+  contents: write
+
+defaults:
+  run:
+    working-directory: ./reference-lib
+    shell: bash
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Tag release if version not yet tagged
+        run: |
+          VERSION=v$(node -p 'require("./package.json").version')
+          if git ls-remote --exit-code --tags origin "refs/tags/$VERSION" >/dev/null 2>&1; then
+            echo "Tag $VERSION already exists, skipping"
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git tag -a "$VERSION" -m "Release $VERSION"
+          git push origin "$VERSION"

--- a/.github/workflows/reference-lib.yml
+++ b/.github/workflows/reference-lib.yml
@@ -1,11 +1,11 @@
-name: Publish to NPM when we get a new tag
+name: reference-lib CI
 
 on:
-  push:
-    tags: ['v*']
+  pull_request:
+    branches: ['main']
+    paths: ['reference-lib/**', '.github/workflows/reference-lib.yml']
 
 permissions:
-  id-token: write
   contents: read
 
 defaults:
@@ -14,17 +14,13 @@ defaults:
     shell: bash
 
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          registry-url: 'https://registry.npmjs.org'
           node-version: 24
-          # keep OIDC tokens away from a possibly poisoned cache
-          package-manager-cache: false
       - run: npm ci
       - run: npm run test
       - run: npm run build
-      - run: npm publish

--- a/reference-lib/package-lock.json
+++ b/reference-lib/package-lock.json
@@ -14,7 +14,8 @@
         "@types/jest": "^29.5.12",
         "jest": "^29.7.0",
         "rollup": "^4.18.0",
-        "ts-jest": "^29.1.4"
+        "ts-jest": "^29.1.4",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -128,6 +129,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.10.tgz",
       "integrity": "sha512-fTmqbbUBAwCcre6zPzNngvsI0aNrPZe77AeqvDxWM9Nm+04RrJ3CAmGHA9f7lJQY6ZMhRztNemy4uslDxTX4Qw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.10",
@@ -1720,6 +1722,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001517",
         "electron-to-chromium": "^1.4.477",
@@ -2565,6 +2568,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -3685,6 +3689,7 @@
       "integrity": "sha512-HqMFpUbWlf/tvcxBFNKnJyzc7Lk+XO3FGc3pbNBLqEbOz0gPLRgcrlS3UF4MfUrVlstOaP/q0kM6GVvi+LrLRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.7"
       },
@@ -4022,7 +4027,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "dev": true,
-      "optional": true,
       "peer": true
     },
     "node_modules/type-detect": {

--- a/reference-lib/package.json
+++ b/reference-lib/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-typescript": "^12.1.0",
+    "tslib": "^2.6.2",
     "@types/jest": "^29.5.12",
     "jest": "^29.7.0",
     "rollup": "^4.18.0",


### PR DESCRIPTION
### Proposed changes

The existing workflow had a few quirks:

- combined PRs and merging to `main`, creating a broader attack surface
- published to npm and _then_ made a git tag. If the git step failed we might have a published package version without a matching tag.
- relied on some github default permissions that could get overridden at the org level to improve security.
- tried to `npm publish` when our dev dependencies change, and failed because the package version was already there. This was some useless noise.

Given the recent spate of npm supply chain attacks, I wanted to revamp this and get a little more explicit.

- split up the PR, tag, and npm publish to three workflows with their own explicit `permissions`
  - the PR workflow runs build/test (reads git)
  - the tag workflow creates a tag after merging to main (read/write to git)
  - the publish workflow uses [trusted publishing](https://docs.npmjs.com/trusted-publishers) to publish the package (reads git, writes to npm)
- disable caching during `npm publish` to dodge the cache poisoning attacks like <https://tanstack.com/blog/npm-supply-chain-compromise-postmortem>. I don't think we were vulnerable to the same things, but github actions is kinda a mess security wise so I'm feeling paranoid
- tweak the tag script to be a no-op if the `package.json` version hasn't changed.


fixes #490, fixes #26

Also adds an explicit dependency to `tslib` to try to get the workflows to actually pass. See #546


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-directive-reference/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-directive-reference/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-directive-reference/blob/main/CHANGELOG.md))
