### PR TITLE
ci: allow manual publish to NPM

### DIFF
--- a/.github/workflows/reference-lib.publish.yml
+++ b/.github/workflows/reference-lib.publish.yml
@@ -3,6 +3,7 @@ name: Publish to NPM when we get a new tag
 on:
   push:
     tags: ['v*']
+  workflow_dispatch:
 
 permissions:
   id-token: write


### PR DESCRIPTION
### Proposed changes

LLMs are liars, the publish workflow does not get triggered by the tag workflow.

https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow

Adding a manual option for now while reworking the actions to get the last month or so worth of changes released.

refs #491

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-directive-reference/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-directive-reference/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-directive-reference/blob/main/CHANGELOG.md))
